### PR TITLE
Update Copyright and License marking.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,33 +1,28 @@
-Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted (subject to the limitations in the
-disclaimer below) provided that the following conditions are met:
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
 
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Qualcomm Innovation Center, Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
-GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
-HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Refer meta-audioreach [README](https://github.com/Audioreach/meta-audioreach?tab
 for instructions to use audioreach-conf on OpenEmbedded system.
 
 ## License
-audioreach-conf is licensed under the BSD-3-Clause-Clear. Check out the [LICENSE](LICENSE) for more details.
+audioreach-conf is licensed under the BSD-3-Clause. Check out the [LICENSE](LICENSE) for more details.

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 set -ex
 
 PREBUILD_SCRIPT_PATH="${PREBUILD_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/pre_build.sh}"

--- a/ci/files_to_copy.sh
+++ b/ci/files_to_copy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 # Move outside the github workspace to avoid conflicts
 cd ..

--- a/linux/kvh2xml.h
+++ b/linux/kvh2xml.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * kvh2xml.h
  *

--- a/qcom/kvh2xml.h
+++ b/qcom/kvh2xml.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * kvh2xml.h
  *

--- a/qcom/qli/GLYMUR/card-defs.xml
+++ b/qcom/qli/GLYMUR/card-defs.xml
@@ -28,7 +28,7 @@
 <!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
 <!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/Kaanapali/card-defs.xml
+++ b/qcom/qli/Kaanapali/card-defs.xml
@@ -28,7 +28,7 @@
 <!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
 <!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/MAHUA/card-defs.xml
+++ b/qcom/qli/MAHUA/card-defs.xml
@@ -28,7 +28,7 @@
 <!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
 <!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/X1E80100/card-defs.xml
+++ b/qcom/qli/X1E80100/card-defs.xml
@@ -28,7 +28,7 @@
 <!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
 <!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/qcm6490/card-defs.xml
+++ b/qcom/qli/qcm6490/card-defs.xml
@@ -25,10 +25,10 @@
 <!--  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN  -->
 <!--  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           -->
 <!--                                                                          -->
-<!--  Changes from Qualcomm Innovation Center are provided under the          -->
+<!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
-<!--  Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.-->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/qcs8275/card-defs.xml
+++ b/qcom/qli/qcs8275/card-defs.xml
@@ -25,10 +25,10 @@
 <!--  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN  -->
 <!--  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           -->
 <!--                                                                          -->
-<!--  Changes from Qualcomm Innovation Center are provided under the          -->
+<!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
-<!--  Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.-->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/qcs8300/card-defs.xml
+++ b/qcom/qli/qcs8300/card-defs.xml
@@ -25,10 +25,10 @@
 <!--  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN  -->
 <!--  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           -->
 <!--                                                                          -->
-<!--  Changes from Qualcomm Innovation Center are provided under the          -->
+<!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
-<!--  Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.-->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/qcs9075/card-defs.xml
+++ b/qcom/qli/qcs9075/card-defs.xml
@@ -25,10 +25,10 @@
 <!--  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN  -->
 <!--  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           -->
 <!--                                                                          -->
-<!--  Changes from Qualcomm Innovation Center are provided under the          -->
+<!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
-<!--  Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.-->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>

--- a/qcom/qli/qcs9100/card-defs.xml
+++ b/qcom/qli/qcs9100/card-defs.xml
@@ -25,10 +25,10 @@
 <!--  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN  -->
 <!--  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           -->
 <!--                                                                          -->
-<!--  Changes from Qualcomm Innovation Center are provided under the          -->
+<!--  Changes from Qualcomm Technologies, Inc. are provided under the         -->
 <!--  following license:                                                      -->
-<!--  Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.-->
-<!--  SPDX-License-Identifier: BSD-3-Clause-Clear                             -->
+<!--  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.      -->
+<!--  SPDX-License-Identifier: BSD-3-Clause                                   -->
 <defs>
 <card>
     <id>100</id>


### PR DESCRIPTION
Replaced "Qualcomm Innovation Center, Inc." with "Qualcomm Technologies, Inc. and/or its subsidiaries" across multiple source files.
SPDX license identifiers changed wherever necessary