### PR TITLE
Remove unused AC_CONFIG_MACRO_DIR from configure files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,6 @@ AC_INIT([audioreach-conf],1.0.0)
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 # defines some macros variable to be included by source
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.
 AC_PROG_CC

--- a/qcom/configure.ac
+++ b/qcom/configure.ac
@@ -11,7 +11,6 @@ AC_INIT([audioreach-conf],1.0.0)
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 # defines some macros variable to be included by source
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.
 AC_PROG_CC

--- a/qcom/qli/configure.ac
+++ b/qcom/qli/configure.ac
@@ -11,7 +11,6 @@ AC_INIT([audioreach-conf],1.0.0)
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 # defines some macros variable to be included by source
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
AC_CONFIG_MACRO_DIR([m4]) was declared in recursive configure files but
the m4/ directory does not exist and contains no custom macros.  This
caused aclocal to fail on Raspberry Pi builds with: "couldn't open
directory 'm4': No such file or directory"