### PR TITLE
Add pre_build script for SDK setup

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -1,6 +1,6 @@
 ---
 name: pre_merge_build
-run-name: Pre Merge Build (PR:${{ github.event.pull_request.number }})
+run-name: ${{ github.event.pull_request.number && 'Pre Merge Build PR:' || 'Pre Merge Build:' }}${{ github.event.pull_request.number || github.run_number }}
 
 on:
   workflow_dispatch:

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,6 +3,17 @@
 #
 # Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
 set -ex
+
+PREBUILD_SCRIPT_PATH="${PREBUILD_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/pre_build.sh}"
+source "$PREBUILD_SCRIPT_PATH"
+
+
+# load build args from file if environment variable is not set
+if [ -z "${BUILD_ARGS}" ]; then
+    BUILD_OPTIONS_FILE="${GITHUB_WORKSPACE}/ci/build_options.txt"
+    BUILD_ARGS="$(sed -E 's/#.*$//' "$BUILD_OPTIONS_FILE" | sed '/^[[:space:]]*$/d' | tr '\n' ' ')"
+fi
+
 echo "Running build script..."
 
 # Build/Compile audioreach-conf

--- a/ci/pre_build.sh
+++ b/ci/pre_build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+set -euo pipefail
+echo "Running pre-build script..."
+
+# Define target_image.json url
+url="https://raw.githubusercontent.com/AudioReach/audioreach-workflows/master/.github/actions/loading/target_image.json"
+
+# Download <sdk>.sh from aws s3 bucket and install the sdk
+if [ ! -d "${GITHUB_WORKSPACE}/install" ]; then
+    if [ -z "${SDK_NAME}" ]; then
+        echo "SDK_NAME environment variable is not set. Fetching from JSON."
+        if curl -fsSL -o target_image.json "${url}"; then
+            SDK=$(jq -r 'to_entries[0].value.SDK_name' target_image.json)
+            if [ -n "$SDK" ] && [ "$SDK" != "null" ]; then
+                export SDK_NAME="$SDK"
+                echo "SDK_NAME set to ${SDK_NAME}"
+            else
+                echo "Error: SDK_name not found in JSON." >&2
+                exit 3
+            fi
+        else
+            echo "Failed to fetch target_image.json from $url" >&2
+            exit 1
+        fi
+    fi
+    if aws s3 cp s3://qli-prd-audior-gh-artifacts/AudioReach/meta-audioreach/post_merge_build/${SDK_NAME} "${GITHUB_WORKSPACE}"; then
+        echo "SDK downloaded successfully."
+        chmod 777 "${GITHUB_WORKSPACE}/${SDK_NAME}"
+    else
+        echo "Failed to download SDK from S3. Exiting."
+        exit 1
+    fi
+    # Setup directory for sdk installation
+    mkdir -p "${GITHUB_WORKSPACE}/install"
+    orig_dir=$(pwd)
+    cd "${GITHUB_WORKSPACE}"
+    # Install the sdk
+    echo "Running SDK script..."
+    if echo "./install" | ./"${SDK_NAME}" ; then
+        echo "SDK Script ran successfully."
+    else
+        echo "Error running SDK script. Exiting."
+        exit 1
+    fi
+    cd "$orig_dir"
+else
+    echo "SDK already installed. Skipping download and installation."
+fi


### PR DESCRIPTION
Introduce a pre_build script that retrieves the SDK from an AWS S3 bucket and executes it during the build. This logic is moved out of the CI GitHub Actions workflow so standalone and local builds can reuse it.