### PR TITLE
CI: Update build files to enable pre-merge compilation

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -18,18 +18,17 @@ echo "Running build script..."
 
 # Build/Compile audioreach-conf
 # make sure we are in the right directory
-cd ${GITHUB_WORKSPACE}
-source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-2a-qcom-linux
-mkdir ${GITHUB_WORKSPACE}/build
-mkdir ${GITHUB_WORKSPACE}/build/etc
-mkdir ${GITHUB_WORKSPACE}/build/etc/acdbdata
-mkdir ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcm6490_rb3
-mkdir ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcs8300
-mkdir ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcs9075
-mkdir ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcs9100
 
-cp -r qcom/qli/qcm6490/card-defs.xml ${GITHUB_WORKSPACE}/build/etc/
-cp -r qcom/qli/qcm6490/acdbdata/* ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcm6490_rb3/
-cp -r qcom/qli/qcs8300/acdbdata/* ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcs8300/
-cp -r qcom/qli/qcs9100/acdbdata/* ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcs9100/
-cp -r qcom/qli/qcs9075/acdbdata/* ${GITHUB_WORKSPACE}/build/etc/acdbdata/qcs9075/
+source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-2a-qcom-linux
+
+cd ${GITHUB_WORKSPACE}
+
+# Run autoreconf to generate the configure script
+autoreconf -Wcross --verbose --install --force --exclude=autopoint
+autoconf --force
+
+# Run the configure script with the specified arguments
+./configure ${BUILD_ARGS}
+
+# make
+make DESTDIR=${GITHUB_WORKSPACE}/build install

--- a/ci/build_options.txt
+++ b/ci/build_options.txt
@@ -1,5 +1,6 @@
 --build=x86_64-linux
---host=aarch64-poky-linux
+--host=aarch64-qcom-linux
+--target=aarch64-qcom-linux
 --prefix=/usr
 --exec_prefix=/usr
 --bindir=/usr/bin
@@ -17,3 +18,4 @@
 --disable-silent-rules
 --disable-dependency-tracking
 --disable-static
+--with-qcom

--- a/ci/files_to_copy.sh
+++ b/ci/files_to_copy.sh
@@ -8,7 +8,3 @@ cd ..
 
 # copy the build artifacts to a temporary directory
 cp -R build/etc/* /tmp/rootfs/etc/
-cp -R build/etc/acdbdata/qcm6490_rb3/* /tmp/rootfs/etc/acdbdata/qcm6490_rb3/
-cp -R build/etc/acdbdata/qcs8300/* /tmp/rootfs/etc/acdbdata/qcs8300/
-cp -R build/etc/acdbdata/qcs9100/*  /tmp/rootfs/etc/acdbdata/qcs9100/
-cp -R build/etc/acdbdata/qcs9075/*  /tmp/rootfs/etc/acdbdata/qcs9075/


### PR DESCRIPTION
Modify build.sh to enable compilation and artifact installation during CI execution.

Modify build_options.txt to pass required build arguments for Qualcomm cross compilation.

Modify files_to_copy.sh to support artifacts used by the pre-merge workflow.