### PR TITLE
qcm6490: add ACDB install path for QCM6490 IDP

### DIFF
--- a/qcom/qli/qcm6490/Makefile.am
+++ b/qcom/qli/qcm6490/Makefile.am
@@ -10,6 +10,9 @@ config_acdbdata = acdbdata/acdb_cal.acdb\
 config_acdbdatadir = $(sysconfdir)/acdbdata/QCS6490_RB3Gen2/
 config_acdbdata_DATA = $(config_acdbdata)
 
+config_acdbdata_idpdir = $(sysconfdir)/acdbdata/QCM6490_IDP/
+config_acdbdata_idp_DATA = $(config_acdbdata)
+
 config_carddef = card-defs.xml
 
 config_carddefdir = $(sysconfdir)


### PR DESCRIPTION
Extend Makefile.am to install existing ACDB calibration files to the QCM6490_IDP sysconf directory, enabling reuse of the same data across RB3Gen2 and IDP boards.