### PR TITLE
CI: Disable armor checkers in qcom preflight workflow

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -14,4 +14,6 @@ permissions:
 jobs:
   qcom-preflight-checks:
     uses: Audioreach/audioreach-workflows/.github/workflows/qcom-preflight-checks.yml@master
+    with:
+      enable-armor-checkers: false
     secrets: inherit


### PR DESCRIPTION
This repository currently does not expose any public headers, so armor checks are not applicable.