### PR TITLE
linux/reference: Add ALSA lib configuration files.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,12 @@ AC_ARG_WITH([qcom],
         [with_qcom=no])
 AM_CONDITIONAL([VENDOR_QCOM], [test "x${with_qcom}" = "xyes"])
 
+AC_ARG_WITH([libalsa],
+    AS_HELP_STRING([--with-libalsa], [Install ALSA and UCM configuration files (default is no)]),
+        [with_libalsa=$withval],
+        [with_libalsa=no])
+AM_CONDITIONAL([HAVE_LIBALSA], [test "x${with_libalsa}" = "xyes"])
+
 AC_CONFIG_FILES([ \
         Makefile \
         linux/Makefile \

--- a/linux/reference/Makefile.am
+++ b/linux/reference/Makefile.am
@@ -15,9 +15,11 @@ config_carddef = card-defs.xml
 config_carddefdir = $(sysconfdir)
 config_carddef_DATA = $(config_carddef)
 
+if HAVE_LIBALSA
 config_alsa_confdir = $(sysconfdir)/alsa/conf.d
 config_alsa_conf_DATA = alsalib/agm.conf
 
 config_ucmdir = $(datadir)/alsa/ucm2/conf.virt.d
 config_ucm_DATA = alsalib/agmvirtualsndcard.conf \
 		  alsalib/PCMPlayback.conf
+endif

--- a/linux/reference/Makefile.am
+++ b/linux/reference/Makefile.am
@@ -14,3 +14,10 @@ config_carddef = card-defs.xml
 
 config_carddefdir = $(sysconfdir)
 config_carddef_DATA = $(config_carddef)
+
+config_alsa_confdir = $(sysconfdir)/alsa/conf.d
+config_alsa_conf_DATA = alsalib/agm.conf
+
+config_ucmdir = $(datadir)/alsa/ucm2/conf.virt.d
+config_ucm_DATA = alsalib/agmvirtualsndcard.conf \
+		  alsalib/PCMPlayback.conf

--- a/linux/reference/alsalib/PCMPlayback.conf
+++ b/linux/reference/alsalib/PCMPlayback.conf
@@ -1,0 +1,31 @@
+Syntax 2
+
+SectionVerb {
+        EnableSequence [
+                cdev "agm"
+                cset "iface=MIXER,name='PCM_RT_PROXY-RX-2 rate ch fmt' 0xbb80,0x2,0x2,0x1"
+                cset "iface=MIXER,name='PCM100 control' PCM_RT_PROXY-RX-2"
+                cset-tlv "iface=MIXER,name='PCM_RT_PROXY-RX-2 metadata' /etc/device_metadata.bin"
+                cset-tlv "iface=MIXER,name='PCM100 metadata' /etc/stream_metadata.bin"
+                cset-tlv "iface=MIXER,name='PCM100 metadata' /etc/stream_device_metadata.bin"
+                cset "iface=MIXER,name='PCM100 connect' PCM_RT_PROXY-RX-2"
+        ]
+        DisableSequence [
+        ]
+
+        Value {
+                PlaybackPCM "agm:100,100"
+        }
+}
+
+SectionDevice."Speaker" {
+        EnableSequence [
+        ]
+
+        DisableSequence [
+        ]
+
+        Value {
+                PlaybackChannels "2"
+        }
+}

--- a/linux/reference/alsalib/agm.conf
+++ b/linux/reference/alsalib/agm.conf
@@ -1,0 +1,25 @@
+pcm.!default {
+    type agm
+    card 100
+    device 100
+}
+
+pcm.agm {
+    @args [ CARD DEV ]
+    @args.CARD {
+        type integer
+        default 100
+    }
+    @args.DEV {
+        type integer
+        default 100
+    }
+    type agm
+    card $CARD
+    device $DEV
+}
+
+ctl.agm {
+    type agm
+    card 100
+}

--- a/linux/reference/alsalib/agmvirtualsndcard.conf
+++ b/linux/reference/alsalib/agmvirtualsndcard.conf
@@ -1,0 +1,27 @@
+Syntax 4
+
+LibraryConfig.agm.Config {
+        pcm.agm {
+                @args [ CARD DEV ]
+                        @args.CARD {
+                        type integer
+                        default 100
+                }
+                @args.DEV {
+                        type integer
+                        default 100
+                }
+                type agm
+                card $CARD
+                device $DEV
+        }
+
+        ctl.agm {
+                type agm
+                card 100
+        }
+}
+
+SectionUseCase."PCMPlayback" {
+        File "PCMPlayback.conf"
+}


### PR DESCRIPTION
linux/reference: Add ALSA lib configuration files.
* Add configuration files required for ALSA lib integration with
AudioReach via AGM.
* Update linux/reference/Makefile.am to install these files to their
respective target paths using $(sysconfdir) and $(datadir) which
resolve to /etc and /usr/share respectively in Yocto builds.
* Add a --with-libalsa configure option (default: no) and use the
resulting HAVE_LIBALSA conditional to gate installation of the
ALSA conf (alsalib/agm.conf) and UCM files (agmvirtualsndcard.conf,
PCMPlayback.conf) so they are only installed when explicitly
configured.

